### PR TITLE
Add horizon artifacts for mqtt

### DIFF
--- a/shared/mqtt/horizon/.gitignore
+++ b/shared/mqtt/horizon/.gitignore
@@ -1,0 +1,1 @@
+/.hzn.json.tmp.mk

--- a/shared/mqtt/horizon/dependencies/.gitignore
+++ b/shared/mqtt/horizon/dependencies/.gitignore
@@ -1,0 +1,1 @@
+*.service.definition.json

--- a/shared/mqtt/horizon/hzn.json
+++ b/shared/mqtt/horizon/hzn.json
@@ -1,0 +1,8 @@
+{
+    "HZN_ORG_ID": "$HZN_ORG_ID",
+    "MetadataVars": {
+        "DOCKER_IMAGE_BASE": "openhorizon/mqtt",
+        "SERVICE_NAME": "mqtt",
+        "SERVICE_VERSION": "1.1.0"
+    }
+}

--- a/shared/mqtt/horizon/pattern-all-arches.json
+++ b/shared/mqtt/horizon/pattern-all-arches.json
@@ -1,0 +1,38 @@
+{
+    "name": "pattern-$SERVICE_NAME",
+    "label": "Edge $SERVICE_NAME Service Pattern for all architectures",
+    "description": "Pattern for $SERVICE_NAME",
+    "public": false,
+    "services": [
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "amd64",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        },
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "arm",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        },
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "arm64",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        }
+    ]
+}

--- a/shared/mqtt/horizon/pattern.json
+++ b/shared/mqtt/horizon/pattern.json
@@ -1,0 +1,18 @@
+{
+    "name": "pattern-${SERVICE_NAME}-$ARCH",
+    "label": "Edge $SERVICE_NAME Service Pattern for $ARCH",
+    "description": "Pattern for $SERVICE_NAME for $ARCH",
+    "public": false,
+    "services": [
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "$ARCH",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        }
+    ]
+}

--- a/shared/mqtt/horizon/service.definition.json
+++ b/shared/mqtt/horizon/service.definition.json
@@ -1,0 +1,27 @@
+{
+    "org": "$HZN_ORG_ID",
+    "label": "$SERVICE_NAME for $ARCH",
+    "description": "An mqtt broker and publisher for inter-container commmunication",
+    "public": true,
+    "documentation": "https://github.com/TheMosquito/achatina/blob/master/shared/mqtt/Makefile",
+    "url": "$SERVICE_NAME",
+    "version": "$SERVICE_VERSION",
+    "arch": "$ARCH",
+    "sharable": "multiple",
+    "requiredServices": [],
+    "userInput": [],
+    "deployment": {
+        "services": {
+            "mqtt": {
+                "image": "${DOCKER_IMAGE_BASE}_$ARCH:$SERVICE_VERSION",
+                "ports": [
+                    {
+                        "HostPort": "1883:1883/tcp",
+                        "HostIP": "127.0.0.1"
+                    }
+                ],
+                "privileged": false
+            }
+        }
+    }
+}


### PR DESCRIPTION
Ran `hzn dev service new -s mqtt -V 1.1.0 -i openhorizon/mqtt --noImageGen` to generate files, and changed `service.definition.json` "description" and "documentation" and `hzn.json` "HZN_ORG_ID" fields based on the [mqtt example in the base open-horizon repo](https://github.com/open-horizon/examples/tree/master/edge/services/mqtt_broker). 

Tested by running a slightly modified version of the test in the Makefile. Because I couldn't get the `mosquito-clients` commands to work locally on my Mac, I instead modified the Dockerfile to install the `mosquito-clients` packages, and then tested the broker by execing into the containers and running the code in the Make `test-sub` and `test-pub` targets.

Signed-off-by: Clement Ng <clementdng@gmail.com>