### PR TITLE
Add horizon artifacts for restcam

### DIFF
--- a/shared/restcam/horizon/.gitignore
+++ b/shared/restcam/horizon/.gitignore
@@ -1,0 +1,1 @@
+/.hzn.json.tmp.mk

--- a/shared/restcam/horizon/dependencies/.gitignore
+++ b/shared/restcam/horizon/dependencies/.gitignore
@@ -1,0 +1,1 @@
+*.service.definition.json

--- a/shared/restcam/horizon/hzn.json
+++ b/shared/restcam/horizon/hzn.json
@@ -1,0 +1,8 @@
+{
+    "HZN_ORG_ID": "$HZN_ORG_ID",
+    "MetadataVars": {
+        "DOCKER_IMAGE_BASE": "openhorizon/restcam",
+        "SERVICE_NAME": "restcam",
+        "SERVICE_VERSION": "1.1.0"
+    }
+}

--- a/shared/restcam/horizon/pattern-all-arches.json
+++ b/shared/restcam/horizon/pattern-all-arches.json
@@ -1,0 +1,38 @@
+{
+    "name": "pattern-$SERVICE_NAME",
+    "label": "Edge $SERVICE_NAME Service Pattern for all architectures",
+    "description": "Pattern for $SERVICE_NAME",
+    "public": false,
+    "services": [
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "amd64",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        },
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "arm",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        },
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "arm64",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        }
+    ]
+}

--- a/shared/restcam/horizon/pattern.json
+++ b/shared/restcam/horizon/pattern.json
@@ -1,0 +1,18 @@
+{
+    "name": "pattern-${SERVICE_NAME}-$ARCH",
+    "label": "Edge $SERVICE_NAME Service Pattern for $ARCH",
+    "description": "Pattern for $SERVICE_NAME for $ARCH",
+    "public": false,
+    "services": [
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "$ARCH",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        }
+    ]
+}

--- a/shared/restcam/horizon/service.definition.json
+++ b/shared/restcam/horizon/service.definition.json
@@ -1,0 +1,52 @@
+{
+    "org": "$HZN_ORG_ID",
+    "label": "$SERVICE_NAME for $ARCH",
+    "description": "A basic REST camera service",
+    "public": true,
+    "documentation": "https://github.com/TheMosquito/achatina/blob/master/shared/restcam/Makefile",
+    "url": "$SERVICE_NAME",
+    "version": "$SERVICE_VERSION",
+    "arch": "$ARCH",
+    "sharable": "multiple",
+    "requiredServices": [],
+    "userInput": [
+        {
+            "name": "CAM_DEVICE",
+            "label": "The source or device to use",
+            "type": "string",
+            "defaultValue": "V4L2:/dev/video0"
+        },
+        {
+            "name": "CAM_DELAY_SEC",
+            "label": "The delay between the CAM_DEVICE initialization and capturing",
+            "type": "int",
+            "defaultValue": "0"
+        },
+        {
+            "name": "CAM_OUT_WIDTH",
+            "label": "Scaled width of image",
+            "type": "int",
+            "defaultValue": "640"
+        },
+        {
+            "name": "CAM_OUT_HEIGHT",
+            "label": "Scaled height of image",
+            "type": "int",
+            "defaultValue": "480"
+        }
+    ],
+    "deployment": {
+        "services": {
+            "restcam": {
+                "image": "${DOCKER_IMAGE_BASE}_$ARCH:$SERVICE_VERSION",
+                "ports": [
+                    {
+                        "HostPort": "8888:80/tcp",
+                        "HostIP": "127.0.0.1"
+                    }
+                ],
+                "privileged": true
+            }
+        }
+    }
+}


### PR DESCRIPTION
Ran `hzn dev service new -s restcam -V 1.1.0 -i openhorizon/restcam --noImageGen --noPolicy` to generate files, and changed `service.definition.json` and `hzn.json` fields to match up with the `make run` arguments. 

Tested by running the example with `hzn dev` and verifying that I could see `test.jpg`when visiting 127.0.0.1:8888 as well as generate the `test.jpg` in the `restcam` directory by running the `make test` (the self-test above the `test` target. 

Signed-off-by: Clement Ng <clementdng@gmail.com>