### PR TITLE
Add horizon artifacts for monitor

### DIFF
--- a/shared/monitor/horizon/.gitignore
+++ b/shared/monitor/horizon/.gitignore
@@ -1,0 +1,1 @@
+/.hzn.json.tmp.mk

--- a/shared/monitor/horizon/dependencies/.gitignore
+++ b/shared/monitor/horizon/dependencies/.gitignore
@@ -1,0 +1,1 @@
+*.service.definition.json

--- a/shared/monitor/horizon/hzn.json
+++ b/shared/monitor/horizon/hzn.json
@@ -1,0 +1,8 @@
+{
+    "HZN_ORG_ID": "$HZN_ORG_ID",
+    "MetadataVars": {
+        "DOCKER_IMAGE_BASE": "openhorizon/monitor",
+        "SERVICE_NAME": "monitor",
+        "SERVICE_VERSION": "1.1.0"
+    }
+}

--- a/shared/monitor/horizon/pattern-all-arches.json
+++ b/shared/monitor/horizon/pattern-all-arches.json
@@ -1,0 +1,38 @@
+{
+    "name": "pattern-$SERVICE_NAME",
+    "label": "Edge $SERVICE_NAME Service Pattern for all architectures",
+    "description": "Pattern for $SERVICE_NAME",
+    "public": false,
+    "services": [
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "amd64",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        },
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "arm",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        },
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "arm64",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        }
+    ]
+}

--- a/shared/monitor/horizon/pattern.json
+++ b/shared/monitor/horizon/pattern.json
@@ -1,0 +1,18 @@
+{
+    "name": "pattern-${SERVICE_NAME}-$ARCH",
+    "label": "Edge $SERVICE_NAME Service Pattern for $ARCH",
+    "description": "Pattern for $SERVICE_NAME for $ARCH",
+    "public": false,
+    "services": [
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "$ARCH",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        }
+    ]
+}

--- a/shared/monitor/horizon/service.definition.json
+++ b/shared/monitor/horizon/service.definition.json
@@ -1,0 +1,34 @@
+{
+    "org": "$HZN_ORG_ID",
+    "label": "$SERVICE_NAME for $ARCH",
+    "description": "Debugging utility for achatina",
+    "public": true,
+    "documentation": "https://github.com/TheMosquito/achatina/blob/master/shared/monitor/Makefile",
+    "url": "$SERVICE_NAME",
+    "version": "$SERVICE_VERSION",
+    "arch": "$ARCH",
+    "sharable": "multiple",
+    "requiredServices": [
+        {
+            "url": "mqtt",
+            "org": "$HZN_ORG_ID",
+            "versionRange": "[0.0.0,INFINITY)",
+            "arch": "$ARCH"
+        }
+    ],
+    "userInput": [],
+    "deployment": {
+        "services": {
+            "monitor": {
+                "image": "${DOCKER_IMAGE_BASE}_$ARCH:$SERVICE_VERSION",
+                "ports": [
+                    {
+                        "HostPort": "5200:5200/tcp",
+                        "HostIP": "0.0.0.0"
+                    }
+                ],
+                "privileged": false
+            }
+        }
+    }
+}


### PR DESCRIPTION
Ran `hzn dev service new -s monitor -V 1.1.0 -i openhorizon/monitor --noImageGen --noPolicy` to generate files and updated `service.definition.json` and `hzn.json` fields appropriately.

Tested by running `hzn dev` and checking that the service was running on http://0.0.0.0:5200/. Currently, that page is displaying the "No data yet." error, so in the future, I will come back and make sure that a proper integration test with achatina (the individual service within this repo) will work.

Signed-off-by: Clement Ng <clementdng@gmail.com>