### PR TITLE
Add horizon artifacts for cpu-only

### DIFF
--- a/plugins/cpu-only/horizon/.gitignore
+++ b/plugins/cpu-only/horizon/.gitignore
@@ -1,0 +1,1 @@
+/.hzn.json.tmp.mk

--- a/plugins/cpu-only/horizon/dependencies/.gitignore
+++ b/plugins/cpu-only/horizon/dependencies/.gitignore
@@ -1,0 +1,1 @@
+*.service.definition.json

--- a/plugins/cpu-only/horizon/hzn.json
+++ b/plugins/cpu-only/horizon/hzn.json
@@ -1,0 +1,8 @@
+{
+    "HZN_ORG_ID": "$HZN_ORG_ID",
+    "MetadataVars": {
+        "DOCKER_IMAGE_BASE": "openhorizon/cpu-only",
+        "SERVICE_NAME": "cpu-only",
+        "SERVICE_VERSION": "1.1.0"
+    }
+}

--- a/plugins/cpu-only/horizon/pattern-all-arches.json
+++ b/plugins/cpu-only/horizon/pattern-all-arches.json
@@ -1,0 +1,38 @@
+{
+    "name": "pattern-$SERVICE_NAME",
+    "label": "Edge $SERVICE_NAME Service Pattern for all architectures",
+    "description": "Pattern for $SERVICE_NAME",
+    "public": false,
+    "services": [
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "amd64",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        },
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "arm",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        },
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "arm64",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        }
+    ]
+}

--- a/plugins/cpu-only/horizon/pattern.json
+++ b/plugins/cpu-only/horizon/pattern.json
@@ -1,0 +1,18 @@
+{
+    "name": "pattern-${SERVICE_NAME}-$ARCH",
+    "label": "Edge $SERVICE_NAME Service Pattern for $ARCH",
+    "description": "Pattern for $SERVICE_NAME for $ARCH",
+    "public": false,
+    "services": [
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "$ARCH",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        }
+    ]
+}

--- a/plugins/cpu-only/horizon/service.definition.json
+++ b/plugins/cpu-only/horizon/service.definition.json
@@ -1,0 +1,34 @@
+{
+    "org": "$HZN_ORG_ID",
+    "label": "$SERVICE_NAME for $ARCH",
+    "description": "A yolo plugin using CPU-only",
+    "public": true,
+    "documentation": "https://github.com/TheMosquito/achatina/blob/master/plugins/cpu-only/Makefile",
+    "url": "$SERVICE_NAME",
+    "version": "$SERVICE_VERSION",
+    "arch": "$ARCH",
+    "sharable": "multiple",
+    "requiredServices": [
+        {
+            "url": "restcam",
+            "org": "$HZN_ORG_ID",
+            "versionRange": "[0.0.0,INFINITY)",
+            "arch": "$ARCH"
+        }
+    ],
+    "userInput": [],
+    "deployment": {
+        "services": {
+            "cpu-only": {
+                "image": "${DOCKER_IMAGE_BASE}_$ARCH:$SERVICE_VERSION",
+                "ports": [
+                    {
+                        "HostPort": "5252:80/tcp",
+                        "HostIP": "127.0.0.1"
+                    }
+                ],
+                "privileged": false
+            }
+        }
+    }
+}


### PR DESCRIPTION
Ran `hzn dev service new -s cpu-only -V 1.1.0 -i openhorizon/cpu-only --noImageGen --noPolicy` to generate files, and changed `service.definition.json` and `hzn.json` fields to match up with the `make run` arguments.

Tested by running examples with `hzn dev` and verifying that the curl test command worked for the [original example image](https://raw.githubusercontent.com/MegaMosquito/achatina/master/shared/restcam/mock.jpg) (`curl http://localhost:5252/detect?url=http%3A%2F%2Fraw.githubusercontent.com/MegaMosquito/achatina/master/shared/restcam/mock.jpg&kind=json`) Later I'll figure out how to connect this up with the `restcam` service so that we can directly use the `restcam` url.

Signed-off-by: Clement Ng <clementdng@gmail.com>