### PR TITLE
Add horizon artifacts for cuda

### DIFF
--- a/plugins/cuda/horizon/.gitignore
+++ b/plugins/cuda/horizon/.gitignore
@@ -1,0 +1,1 @@
+/.hzn.json.tmp.mk

--- a/plugins/cuda/horizon/dependencies/.gitignore
+++ b/plugins/cuda/horizon/dependencies/.gitignore
@@ -1,0 +1,1 @@
+*.service.definition.json

--- a/plugins/cuda/horizon/hzn.json
+++ b/plugins/cuda/horizon/hzn.json
@@ -1,0 +1,8 @@
+{
+    "HZN_ORG_ID": "$HZN_ORG_ID",
+    "MetadataVars": {
+        "DOCKER_IMAGE_BASE": "openhorizon/cuda",
+        "SERVICE_NAME": "cuda",
+        "SERVICE_VERSION": "1.1.0"
+    }
+}

--- a/plugins/cuda/horizon/pattern-all-arches.json
+++ b/plugins/cuda/horizon/pattern-all-arches.json
@@ -1,0 +1,38 @@
+{
+    "name": "pattern-$SERVICE_NAME",
+    "label": "Edge $SERVICE_NAME Service Pattern for all architectures",
+    "description": "Pattern for $SERVICE_NAME",
+    "public": false,
+    "services": [
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "amd64",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        },
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "arm",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        },
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "arm64",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        }
+    ]
+}

--- a/plugins/cuda/horizon/pattern.json
+++ b/plugins/cuda/horizon/pattern.json
@@ -1,0 +1,18 @@
+{
+    "name": "pattern-${SERVICE_NAME}-$ARCH",
+    "label": "Edge $SERVICE_NAME Service Pattern for $ARCH",
+    "description": "Pattern for $SERVICE_NAME for $ARCH",
+    "public": false,
+    "services": [
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "$ARCH",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        }
+    ]
+}

--- a/plugins/cuda/horizon/service.definition.json
+++ b/plugins/cuda/horizon/service.definition.json
@@ -1,0 +1,34 @@
+{
+    "org": "$HZN_ORG_ID",
+    "label": "$SERVICE_NAME for $ARCH",
+    "description": "A yolo plugin using CUDA",
+    "public": true,
+    "documentation": "https://github.com/TheMosquito/achatina/blob/master/plugins/cuda/Makefile",
+    "url": "$SERVICE_NAME",
+    "version": "$SERVICE_VERSION",
+    "arch": "$ARCH",
+    "sharable": "multiple",
+    "requiredServices": [
+        {
+            "url": "restcam",
+            "org": "$HZN_ORG_ID",
+            "versionRange": "[0.0.0,INFINITY)",
+            "arch": "$ARCH"
+        }
+    ],
+    "userInput": [],
+    "deployment": {
+        "services": {
+            "cuda": {
+                "image": "${DOCKER_IMAGE_BASE}_$ARCH:$SERVICE_VERSION",
+                "ports": [
+                    {
+                        "HostPort": "5252:80/tcp",
+                        "HostIP": "127.0.0.1"
+                    }
+                ],
+                "privileged": false
+            }
+        }
+    }
+}


### PR DESCRIPTION
Ran `hzn dev service new -s cuda -V 1.1.0 -i openhorizon/cuda --noImageGen --noPolicy` to generate files, and changed `service.definition.json` and `hzn.json` fields to match up with the make run arguments.

Since I don't have an NVIDIA GPU hardware, software, and config, I just tested that `hzn dev` commands starts up a container with the right address and port.

Signed-off-by: Clement Ng <clementdng@gmail.com>