### PR TITLE
Add horizon artifacts for openvino

### DIFF
--- a/plugins/openvino/horizon/.gitignore
+++ b/plugins/openvino/horizon/.gitignore
@@ -1,0 +1,1 @@
+/.hzn.json.tmp.mk

--- a/plugins/openvino/horizon/dependencies/.gitignore
+++ b/plugins/openvino/horizon/dependencies/.gitignore
@@ -1,0 +1,1 @@
+*.service.definition.json

--- a/plugins/openvino/horizon/hzn.json
+++ b/plugins/openvino/horizon/hzn.json
@@ -1,0 +1,8 @@
+{
+    "HZN_ORG_ID": "$HZN_ORG_ID",
+    "MetadataVars": {
+        "DOCKER_IMAGE_BASE": "openhorizon/openvino",
+        "SERVICE_NAME": "openvino",
+        "SERVICE_VERSION": "1.1.0"
+    }
+}

--- a/plugins/openvino/horizon/pattern-all-arches.json
+++ b/plugins/openvino/horizon/pattern-all-arches.json
@@ -1,0 +1,38 @@
+{
+    "name": "pattern-$SERVICE_NAME",
+    "label": "Edge $SERVICE_NAME Service Pattern for all architectures",
+    "description": "Pattern for $SERVICE_NAME",
+    "public": false,
+    "services": [
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "amd64",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        },
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "arm",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        },
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "arm64",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        }
+    ]
+}

--- a/plugins/openvino/horizon/pattern.json
+++ b/plugins/openvino/horizon/pattern.json
@@ -1,0 +1,18 @@
+{
+    "name": "pattern-${SERVICE_NAME}-$ARCH",
+    "label": "Edge $SERVICE_NAME Service Pattern for $ARCH",
+    "description": "Pattern for $SERVICE_NAME for $ARCH",
+    "public": false,
+    "services": [
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "$ARCH",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        }
+    ]
+}

--- a/plugins/openvino/horizon/service.definition.json
+++ b/plugins/openvino/horizon/service.definition.json
@@ -1,0 +1,36 @@
+{
+    "org": "$HZN_ORG_ID",
+    "label": "$SERVICE_NAME for $ARCH",
+    "description": "A yolo plugin using openvino",
+    "public": true,
+    "documentation": "https://github.com/TheMosquito/achatina/blob/master/plugins/openvino/Makefile",
+    "url": "$SERVICE_NAME",
+    "version": "$SERVICE_VERSION",
+    "arch": "$ARCH",
+    "sharable": "multiple",
+    "requiredServices": [
+        {
+            "url": "restcam",
+            "org": "$HZN_ORG_ID",
+            "versionRange": "[0.0.0,INFINITY)",
+            "arch": "$ARCH"
+        }
+    ],
+    "userInput": [
+        {
+            "name": "OPENVINO_PLUGIN",
+            "label": "The openvino plugin",
+            "type": "string",
+            "defaultValue": "MYRIAD"
+        }
+    ],
+    "deployment": {
+        "services": {
+            "openvino": {
+                "image": "${DOCKER_IMAGE_BASE}_$ARCH:$SERVICE_VERSION",
+                "privileged": true,
+                "devices": ["/dev:/dev"]
+            }
+        }
+    }
+}


### PR DESCRIPTION
Ran `hzn dev service new -s openvino -V 1.1.0 -i openhorizon/openvino --noImageGen --noPolicy` to generate files, and changed `service.definition.json` (`privileged`, `devices`, and `userInput`) and `hzn.json` fields to match up with the make run arguments.

Since I don't have Movidius hardware, I can't locally build the containers to test this change. However, I can verify that `hzn dev` doesn't crash due to syntax errors.

Signed-off-by: Clement Ng <clementdng@gmail.com>