### PR TITLE
Add horizon artifacts for achatina

### DIFF
--- a/achatina/horizon/.gitignore
+++ b/achatina/horizon/.gitignore
@@ -1,0 +1,1 @@
+/.hzn.json.tmp.mk

--- a/achatina/horizon/dependencies/.gitignore
+++ b/achatina/horizon/dependencies/.gitignore
@@ -1,0 +1,1 @@
+*.service.definition.json

--- a/achatina/horizon/hzn.json
+++ b/achatina/horizon/hzn.json
@@ -1,0 +1,8 @@
+{
+    "HZN_ORG_ID": "$HZN_ORG_ID",
+    "MetadataVars": {
+        "DOCKER_IMAGE_BASE": "openhorizon/achatina",
+        "SERVICE_NAME": "achatina",
+        "SERVICE_VERSION": "2.0.0"
+    }
+}

--- a/achatina/horizon/pattern-all-arches.json
+++ b/achatina/horizon/pattern-all-arches.json
@@ -1,0 +1,38 @@
+{
+    "name": "pattern-$SERVICE_NAME",
+    "label": "Edge $SERVICE_NAME Service Pattern for all architectures",
+    "description": "Pattern for $SERVICE_NAME",
+    "public": false,
+    "services": [
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "amd64",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        },
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "arm",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        },
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "arm64",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        }
+    ]
+}

--- a/achatina/horizon/pattern.json
+++ b/achatina/horizon/pattern.json
@@ -1,0 +1,18 @@
+{
+    "name": "pattern-${SERVICE_NAME}-$ARCH",
+    "label": "Edge $SERVICE_NAME Service Pattern for $ARCH",
+    "description": "Pattern for $SERVICE_NAME for $ARCH",
+    "public": false,
+    "services": [
+        {
+            "serviceUrl": "$SERVICE_NAME",
+            "serviceOrgid": "$HZN_ORG_ID",
+            "serviceArch": "$ARCH",
+            "serviceVersions": [
+                {
+                    "version": "$SERVICE_VERSION"
+                }
+            ]
+        }
+    ]
+}

--- a/achatina/horizon/service.definition.json
+++ b/achatina/horizon/service.definition.json
@@ -1,0 +1,101 @@
+{
+    "org": "$HZN_ORG_ID",
+    "label": "$SERVICE_NAME for $ARCH",
+    "description": "A top-level service that takes an image and sends it to a visual inferencing plugin and publishes results to an MQTT broker and optionally a Kafka broker",
+    "public": true,
+    "documentation": "https://github.com/TheMosquito/achatina/blob/master/achatina/Makefile",
+    "url": "$SERVICE_NAME",
+    "version": "$SERVICE_VERSION",
+    "arch": "$ARCH",
+    "sharable": "multiple",
+    "requiredServices": [
+        {
+            "url": "$ACHATINA_PLUGIN",
+            "org": "$HZN_ORG_ID",
+            "versionRange": "[0.0.0,INFINITY)",
+            "arch": "$ARCH"
+        },
+        {
+            "url": "mqtt",
+            "org": "$HZN_ORG_ID",
+            "versionRange": "[0.0.0,INFINITY)",
+            "arch": "$ARCH"
+        },
+        {
+            "url": "cpu-only",
+            "org": "myorg",
+            "versionRange": "1.1.0",
+            "arch": "amd64"
+        }
+    ],
+    "userInput": [
+        {
+            "name": "ACHATINA_PLUGIN",
+            "label": "The visual inferencing plugin to use",
+            "type": "string",
+            "defaultValue": "cpu-only"
+        },
+        {
+            "name": "MQTT_BROKER_ADDRESS",
+            "label": "The MQTT broker to publish to",
+            "type": "string",
+            "defaultValue": "mqtt"
+        },
+        {
+            "name": "MQTT_BROKER_PORT",
+            "label": "The MQTT broker port",
+            "type": "string",
+            "defaultValue": "1883"
+        },
+        {
+            "name": "MQTT_PUB_TOPIC",
+            "label": "The MQTT topic to publish to",
+            "type": "string",
+            "defaultValue": "/detect"
+        },
+        {
+            "name": "KAFKA_BROKER_URLS",
+            "label": "Comma-separated list of broker URLs in your Kafka broker pool",
+            "type": "string",
+            "defaultValue": ""
+        },
+        {
+            "name": "KAFKA_API_KEY",
+            "label": "The Kafka API key",
+            "type": "string",
+            "defaultValue": ""
+        },
+        {
+            "name": "KAFKA_PUB_TOPIC",
+            "label": "The Kafka topic to publish to",
+            "type": "string",
+            "defaultValue": ""
+        },
+        {
+            "name": "INPUT_URL",
+            "label": "The image source you want to run achatina on",
+            "type": "string",
+            "defaultValue": ""
+        },
+        {
+            "name": "NODE",
+            "label": "The name of the NODE",
+            "type": "string",
+            "defaultValue": ""
+        },
+        {
+            "name": "HOST_IP",
+            "label": "The default interface IP address of the NODE",
+            "type": "string",
+            "defaultValue": ""
+        }
+    ],
+    "deployment": {
+        "services": {
+            "achatina": {
+                "image": "${DOCKER_IMAGE_BASE}_$ARCH:$SERVICE_VERSION",
+                "privileged": false
+            }
+        }
+    }
+}

--- a/achatina/horizon/userinput.json
+++ b/achatina/horizon/userinput.json
@@ -1,0 +1,16 @@
+{
+    "services": [
+        {
+            "org": "$HZN_ORG_ID",
+            "url": "$SERVICE_NAME",
+            "variables": {
+                "KAFKA_BROKER_URLS": "$KAFKA_BROKER_URLS",
+                "KAFKA_API_KEY": "$KAFKA_API_KEY",
+                "KAFKA_PUB_TOPIC": "$KAFKA_PUB_TOPIC",
+                "INPUT_URL": "$INPUT_URL",
+                "NODE": "$NODE",
+                "HOST_IP": "$HOST_IP"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Ran `hzn dev service new -s achatina -V 2.0.0 -i openhorizon/achatina --noImageGen --noPolicy` to generate files and updated `service.definition.json` and `hzn.json` fields appropriately.

Tested by running `hzn dev` and checking that the three shared services and the plugins were started up and running.

Signed-off-by: Clement Ng <clementdng@gmail.com>