### PR TITLE
Change sharable attribute of mqtt to singleton

### DIFF
--- a/shared/mqtt/horizon/service.definition.json
+++ b/shared/mqtt/horizon/service.definition.json
@@ -7,7 +7,7 @@
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",
     "arch": "$ARCH",
-    "sharable": "multiple",
+    "sharable": "singleton",
     "requiredServices": [],
     "userInput": [],
     "deployment": {


### PR DESCRIPTION
Since `monitor` and `achatina` both depend on `mqtt` as a service to communicate, we need to set the `sharable` attribute to be `singleton` for both of the top-level services to run. For now, all the top-level services are going to be run on the same node and the service implementations cannot tolerate multiple instances of `mqtt` because we'll run into the following error message without this change:
`Error: 'service start' unable to start container using service(s) mqtt, error: API error (500): driver failed programming external connectivity on endpoint myorg_mqtt_1.1.0_f8e0e673-4f63-4cd4-a8a5-2b4d631bb045-mqtt (63772bad112b63bf0dc3f10f87acb57f262e48958b489cac2a2b07e65bd3ecb1): Bind for 127.0.0.1:1883 failed: port is already allocated for dependency mqtt`

Tested that both `achatina` and `monitor` are able to run together on the same device.

Signed-off-by: Clement Ng <clementdng@gmail.com>