### PR TITLE
Rename MQTT_BROKER_ADDRESS to MQTT_BROKER_URL in achatina service def

### DIFF
--- a/achatina/horizon/service.definition.json
+++ b/achatina/horizon/service.definition.json
@@ -36,7 +36,7 @@
             "defaultValue": "cpu-only"
         },
         {
-            "name": "MQTT_BROKER_ADDRESS",
+            "name": "MQTT_BROKER_URL",
             "label": "The MQTT broker to publish to",
             "type": "string",
             "defaultValue": "mqtt"


### PR DESCRIPTION
As discussed in this [PR](https://github.com/MegaMosquito/achatina/pull/6), we want to rename the `MQTT_BROKER_ADDRESS` env variable to `MQTT_BROKER_URL`. This commit updates the `achatina` service definition itself, which was using the old env variable.
 
Signed-off-by: Clement Ng <clementdng@gmail.com>