### PR TITLE
Change sharable attribute of cpu-only to singleton

### DIFF
--- a/plugins/cpu-only/horizon/service.definition.json
+++ b/plugins/cpu-only/horizon/service.definition.json
@@ -7,7 +7,7 @@
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",
     "arch": "$ARCH",
-    "sharable": "multiple",
+    "sharable": "singleton",
     "requiredServices": [
         {
             "url": "restcam",


### PR DESCRIPTION
We want to enable this service to run as a single instance on multiple clients.

Signed-off-by: Clement Ng <clementdng@gmail.com>