### PR TITLE
Add simpler publish make targets for mqtt

### DIFF
--- a/shared/mqtt/Makefile
+++ b/shared/mqtt/Makefile
@@ -26,9 +26,14 @@ include ../../checks.mk
 # Give this service a name and version number
 SERVICE_NAME:="mqtt"
 SERVICE_VERSION:="1.1.0"
+PATTERN_NAME:="pattern-mqtt"
 
 # These statements automatically configure some environment variables
 ARCH:=$(shell ../../helper -a)
+
+# Leave blank for open DockerHub containers
+# CONTAINER_CREDS:=-r "registry.wherever.com:myid:mypw"
+CONTAINER_CREDS:=
 
 build: check-dockerhubid
 	docker build -t $(DOCKERHUB_ID)/$(SERVICE_NAME)_$(ARCH):$(SERVICE_VERSION) -f ./Dockerfile.$(ARCH) .
@@ -68,5 +73,25 @@ clean: check-dockerhubid
 	-docker rmi $(DOCKERHUB_ID)/$(SERVICE_NAME)_$(ARCH):$(SERVICE_VERSION) 2>/dev/null || :
 	-docker network rm mqtt-net 2>/dev/null || :
 
-.PHONY: build run test test-sub test-pub stop clean
+publish-service:
+	@ARCH=$(ARCH) \
+	    SERVICE_NAME="$(SERVICE_NAME)" \
+	    SERVICE_VERSION="$(SERVICE_VERSION)"\
+	    SERVICE_CONTAINER="$(DOCKERHUB_ID)/$(SERVICE_NAME):$(SERVICE_VERSION)" \
+	    hzn exchange service publish -O $(CONTAINER_CREDS) -P -f horizon/service.definition.json
+
+publish-pattern:
+	@ARCH=$(ARCH) \
+	    SERVICE_NAME="$(SERVICE_NAME)" \
+	    SERVICE_VERSION="$(SERVICE_VERSION)"\
+	    PATTERN_NAME="$(PATTERN_NAME)" \
+	    hzn exchange pattern publish -f horizon/pattern.json
+
+agent-run:
+	hzn register --pattern "${HZN_ORG_ID}/$(PATTERN_NAME)"
+
+agent-stop:
+	hzn unregister -f
+
+.PHONY: build run test test-sub test-pub stop clean publish-service publish-pattern agent-run agent-stop
 


### PR DESCRIPTION
Added `publish-pattern`, `publish-service`, `agent-run`, and `agent-stop`. Based on Glen's Makefile additions [here](https://github.com/TheMosquito/web-hello-cpp/commit/2d51a94c0b795aefd44b881bdca0def86f3b8cb4). A future PR will refactor the `horizon` artifacts to be simpler.

Tested that added targets work.

Signed-off-by: Clement Ng <clementdng@gmail.com>