### PR TITLE
Use `$PATTERN_NAME` in the mqtt pattern.json

### DIFF
--- a/shared/mqtt/pattern.json
+++ b/shared/mqtt/pattern.json
@@ -1,5 +1,5 @@
 {
-    "name": "pattern-${SERVICE_NAME}-$ARCH",
+    "name": "$PATTERN_NAME",
     "label": "Edge $SERVICE_NAME Service Pattern for $ARCH",
     "description": "Pattern for $SERVICE_NAME for $ARCH",
     "public": false,


### PR DESCRIPTION
I realized we weren't actually using the `$PATTERN_NAME` env variable to set the pattern name in `pattern.json`.

Signed-off-by: Clement Ng <clementdng@gmail.com>