### PR TITLE
Removed `$DOCKER_IMAGE_BASE` from mqtt service.json

### DIFF
--- a/shared/mqtt/Makefile
+++ b/shared/mqtt/Makefile
@@ -77,7 +77,7 @@ publish-service:
 	@ARCH=$(ARCH) \
 	    SERVICE_NAME="$(SERVICE_NAME)" \
 	    SERVICE_VERSION="$(SERVICE_VERSION)"\
-	    SERVICE_CONTAINER="$(DOCKERHUB_ID)/$(SERVICE_NAME):$(SERVICE_VERSION)" \
+	    SERVICE_CONTAINER="$(DOCKERHUB_ID)/$(SERVICE_NAME)_$(ARCH):$(SERVICE_VERSION)" \
 	    hzn exchange service publish -O $(CONTAINER_CREDS) -P -f service.json
 
 publish-pattern:

--- a/shared/mqtt/service.json
+++ b/shared/mqtt/service.json
@@ -13,7 +13,7 @@
     "deployment": {
         "services": {
             "mqtt": {
-                "image": "${DOCKER_IMAGE_BASE}_$ARCH:$SERVICE_VERSION",
+                "image": "$SERVICE_CONTAINER",
                 "ports": [
                     {
                         "HostPort": "1883:1883/tcp",


### PR DESCRIPTION
`$DOCKER_IMAGE_BASE` is a holdover from open horizon examples, but now the service image name should be derived from the `SERVICE_CONTAINER`, which is defined in the `publish-service` Makefile target.

Tested that `make build` and `make publish-service` still work. The reason they worked in past commits is because I had `$DOCKER_IMAGE_BASE` set in my environment.

Signed-off-by: Clement Ng <clementdng@gmail.com>