### PR TITLE
Remove cpu-only service from achatina required services

### DIFF
--- a/achatina/horizon/service.definition.json
+++ b/achatina/horizon/service.definition.json
@@ -20,12 +20,6 @@
             "org": "$HZN_ORG_ID",
             "versionRange": "[0.0.0,INFINITY)",
             "arch": "$ARCH"
-        },
-        {
-            "url": "cpu-only",
-            "org": "myorg",
-            "versionRange": "1.1.0",
-            "arch": "amd64"
         }
     ],
     "userInput": [


### PR DESCRIPTION
I accidentally left this in while I was trying to get `achatina/achatina` to work. The plugin service should be covered by the `$ACHATINA_PLUGIN` above.

Signed-off-by: Clement Ng <clementdng@gmail.com>