### PR TITLE
Add `$ACHATINA_PLUGIN` env variable to achatina publish-service make target

### DIFF
--- a/achatina/Makefile
+++ b/achatina/Makefile
@@ -120,6 +120,7 @@ publish-service:
         SERVICE_NAME="$(SERVICE_NAME)" \
         SERVICE_VERSION="$(SERVICE_VERSION)"\
         SERVICE_CONTAINER="$(DOCKERHUB_ID)/$(SERVICE_NAME):$(SERVICE_VERSION)" \
+        ACHATINA_PLUGIN=$(or ${ACHATINA_PLUGIN},cpu-only) \
         hzn exchange service publish -O $(CONTAINER_CREDS) -P -f horizon/service.definition.json
 
 publish-pattern:


### PR DESCRIPTION
Adds some fallback logic in case `$ACHATINA_PLUGIN` env variable is not set, based on existing logic in the makefile targets above. Originally, I thought that defining the value in the `userInputs` in the service definition could cover the env variable not being set, but running `make publish-service` will result in the error below:

```
Error: Error validating the input service: Error retrieving service from the Exchange for {URL: , Org: <$HZN_ORG_ID>, Version: , VersionRange: [0.0.0,INFINITY), Arch: amd64}. expecting at least 1 service  <$HZN_ORG_ID> [0.0.0,INFINITY), got 0
make: *** [publish-service] Error 1
```

Since we've copied over the fallback logic 3 times, maybe there can be a future commit that pulls that logic into a single variable.

Signed-off-by: Clement Ng <clementdng@gmail.com>